### PR TITLE
Better travis build?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,34 @@
 language: generic
-sudo: required
+sudo: false
 dist: trusty
 notifications:
   email: false
+   
+addons:
+  apt:
+    sources: 
+      - ubuntu-toolchain-r-test
+    packages:
+      - libgtest-dev
+      - expect
+      - libboost-program-options-dev
+      - libboost-filesystem-dev
 
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libgtest-dev
-  - sudo apt-get install -y libboost-program-options-dev libboost-filesystem-dev
-  - sudo apt-get install g++-5
-  - sudo apt-get install expect
-
-  - bash -c "cp -R /usr/src/gtest /tmp/ && cd /tmp/gtest && cmake -DBUILD_SHARED_LIBS=ON . && make && sudo mv libgtest* /usr/local/lib/"
-
+before_script:
+  - mkdir GTEST_BUILD
+  - cd GTEST_BUILD
+  - cmake -DBUILD_SHARED_LIBS=ON /usr/src/gtest
+  - make
+  - cd -
+  
 script:
   - mkdir BUILD
   - cd BUILD
-  - cmake ..
+  - GTEST_ROOT=../GTEST_BUILD cmake ..
   - make
   - make test
 
 matrix:
   include:
     - os: linux
-      env: COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5 CTEST_OUTPUT_ON_FAILURE=1
+      env: COMPILER_NAME=clang CXX=clang++ CC=clang CTEST_OUTPUT_ON_FAILURE=1


### PR DESCRIPTION
This request makes a travis build that is not dependent on the sudo: option so it will build in a container. And it uses the clang compiler which shows up in the cmake.sh file at the root. That seems prudent if travis will build it, and it has succesfully built it for me.  This has been a huge learning experience for me with git, github and travis. I've seen .travis.yml files many times but never needed to learn how they were being used.....
I don't know why the pull request #2 got pulled in nor how to reject it.  Help?

Review and comments are welcomed!  I'll hold off to commit until I've heard from @sakhnik.